### PR TITLE
python3-byte-decoding

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1933,6 +1933,8 @@ def get_username():
                 s = p.stdout.read()
                 p.wait()
                 user = s.strip()
+                if type(user) is bytes:
+                    user = decode(user)
             except:
                 pass
         if not user:


### PR DESCRIPTION
This PR will decode the current name of the user in get_username() in lib/init/grass.py for python3 usage.
For python2 nothing changes, for python3 it would be of type bytes and break things because  b'user' is treated as string and needs to be decoded.