### PR TITLE
[testsuite] Do not hardcode the path to GRASSSRC

### DIFF
--- a/testsuite/examples/test_framework_GRASS_GIS_with_NC.conf
+++ b/testsuite/examples/test_framework_GRASS_GIS_with_NC.conf
@@ -3,7 +3,7 @@
 # name of binary:
 GRASSBIN=grass77
 # source code directory as full path:
-GRASSSRC="$HOME/software/grass77"
+GRASSSRC="$(realpath ../../)"
 # temporary grassdata directory
 GRASSDATA="$HOME/grassdata/tests-grassdata"
 


### PR DESCRIPTION
The hardcoded path makes it difficult to run the testsuite without
modifying the configuration file. By using a relative path, anyone can
run the testuite without any modifications.