### PR TITLE
Update pygrass_raster.rst

### DIFF
--- a/lib/python/docs/src/pygrass_raster.rst
+++ b/lib/python/docs/src/pygrass_raster.rst
@@ -11,8 +11,8 @@ PyGRASS uses 3 different raster classes, that respect the 3 different
 approaches of GRASS-C API. The classes use a standardized interface to
 keep methods consistent between them. The read access is row wise for
 :ref:`RasterRow-label` and :ref:`RasterRowIO-label` and additionally
-cached in the RowIO class. Both classes write sequentially.  RowIO is
-row cached, :ref:`RasterSegment-label` is tile cached for reading and
+cached in the RowIO class. Only the first class writes, and that sequentially.
+RowIO is row cached, :ref:`RasterSegment-label` is tile cached for reading and
 writing; therefore, random access is possible.  Hence RasterRow and
 RasterRowIO should be used for fast (cached) row read access and
 RasterRow for fast sequential writing.  RasterSegment should be used


### PR DESCRIPTION
In the [Introduction to Raster](https://grass.osgeo.org/grass77/manuals/libpython/pygrass_raster.html) classes, please the remove the incorrect short sentence
>Both classes write sequentially.

from

>The read access is row wise for RasterRow? and RasterRowIO and additionally cached in the RowIO class. Both classes write sequentially.

Only [RasterRow](https://grass.osgeo.org/grass77/manuals/libpython/pygrass_raster.html#rasterrow-label) (that is only one class) writes sequentially.

See also: https://trac.osgeo.org/grass/ticket/3766