### PR TITLE
Update r.stats' manual on -x flag

### DIFF
--- a/raster/r.stats/r.stats.html
+++ b/raster/r.stats/r.stats.html
@@ -16,9 +16,10 @@ will be stated also in number of cells.
 <h2>NOTES</h2>
 
 If a single raster map is specified, a list of categories will be
-printed. If multiple raster maps are specified, a cross-tabulation
-table for each combination of categories in the raster maps will be
-printed.
+printed. The <b>-x<b> flag will print x and y (column and row) starting with 1
+(both first row and first column are indexed with 1). If multiple raster maps
+are specified, a cross-tabulation table for each combination of categories in
+the raster maps will be printed.
 
 <p>
 For example, if one raster map was specified, the output would look like:


### PR DESCRIPTION
`r.stats -x` indexes rows and columns starting with 1, while `[gdallocationinfo](https://www.gdal.org/gdallocationinfo.html)` starts with 0 (first row and first column are 0). See also: https://lists.osgeo.org/pipermail/grass-user/2019-March/080114.html; https://lists.osgeo.org/pipermail/grass-user/2019-March/080115.html.