### PR TITLE
r.in.wms: add proxy for GDAL driver

### DIFF
--- a/scripts/r.in.wms/r.in.wms.py
+++ b/scripts/r.in.wms/r.in.wms.py
@@ -145,6 +145,13 @@ This program is free software under the GNU General Public License
 #% guisection: Map style
 #%end
 
+#%option
+#% key: proxy
+#% label: Http proxy only GDAL driver (GDAL_HTTP_PROXY)
+#% type: string
+#% description: Http proxy
+#%end
+
 #%option G_OPT_F_BIN_INPUT
 #% key: capfile
 #% required: no
@@ -227,6 +234,9 @@ def main():
         wms.GetCapabilities(options)
     else:
         from wms_base import GRASSImporter
+        if options['proxy']:
+            wms.setProxy(options['proxy'])
+
         options['region'] = GetRegionParams(options['region'])
         fetched_map = wms.GetMap(options, flags)
 

--- a/scripts/r.in.wms/wms_gdal_drv.py
+++ b/scripts/r.in.wms/wms_gdal_drv.py
@@ -35,6 +35,9 @@ class NullDevice():
 
 class WMSGdalDrv(WMSBase):
 
+    def setProxy(self, proxy):
+        self.proxy = proxy
+
     def _createXML(self):
         """!Create XML for GDAL WMS driver
 
@@ -127,6 +130,9 @@ class WMSGdalDrv(WMSBase):
         temp_map = self._tempfile()
 
         xml_file = self._createXML()
+
+        if hasattr(self, 'proxy'):
+            gdal.SetConfigOption('GDAL_HTTP_PROXY', self.proxy)
         wms_dataset = gdal.Open(xml_file, gdal.GA_ReadOnly)
         grass.try_remove(xml_file)
         if wms_dataset is None:


### PR DESCRIPTION
- A http proxy is added only for the download with the GDAL driver
- not for GetCapabilities